### PR TITLE
fix: dynamic providers, to set the state correctly

### DIFF
--- a/examples/dynamic-state/grant/config.json
+++ b/examples/dynamic-state/grant/config.json
@@ -6,6 +6,9 @@
   "google": {
     "key": "APP_ID",
     "secret": "APP_SECRET",
+    "dynamic": true
   },
-  "twitter": {}
+  "twitter": {
+    "dynamic": true
+  }
 }


### PR DESCRIPTION
without the dynamic param it errors out when passing the state into grant

```bash
Exception: TypeError: Cannot read property 'includes' of undefined
Stack: TypeError: Cannot read property 'includes' of undefined
    at C:\grant-azure\examples\dynamic-state\node_modules\grant\lib\config.js:193:47
    at Array.filter (<anonymous>)
    at Function.provider (C:\grant-azure\examples\dynamic-state\node_modules\grant\lib\config.js:193:14)
    at C:\grant-azure\examples\dynamic-state\node_modules\grant\lib\request.js:30:26
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async app (C:\grant-azure\examples\dynamic-state\node_modules\grant\lib\handler\azure.js:28:43)
    at async module.exports (C:\grant-azure\examples\dynamic-state\grant\index.js:16:39).
```

missing `provider.dynamic === true` condition:
```js
  if ((session.dynamic && provider.dynamic) || _state.dynamic) {
    var dynamic = Object.assign(
      {},
      _state.dynamic,
      provider.dynamic === true
        ? session.dynamic
        : Object.keys(session.dynamic || {})
            .filter((key) => provider.dynamic.includes(key))
            .reduce((all, key) => (all[key] = session.dynamic[key], all), {})
    )
    provider = init(provider, dynamic)
  }
```